### PR TITLE
TRA458: Sleep-In Logic – Implement sleepIn(weekday, vacation)

### DIFF
--- a/plag_test_tool/from_Haitham/TRA458.java
+++ b/plag_test_tool/from_Haitham/TRA458.java
@@ -1,0 +1,10 @@
+public class TRA458{  
+public static boolean sleepIn(boolean weekday, boolean vacation) {
+        if (!weekday) {
+            return true;
+        } else if (vacation) {
+            return true;
+        }
+        return false;
+    }
+	}


### PR DESCRIPTION
The sleepIn method in the TRA458 class checks whether a person can sleep in based on two conditions: if it's not a weekday or if the person is on vacation, then they can sleep in (returns true); otherwise, they can't (returns false).