### PR TITLE
TRA491: Sum Double – Return Sum or Double the Sum

### DIFF
--- a/plag_test_tool/from_Haitham/TRA491.java
+++ b/plag_test_tool/from_Haitham/TRA491.java
@@ -1,0 +1,11 @@
+public class TRA491{
+public static int sumDouble(int a, int b) {
+        int sum = 0;
+        if (a == b) {
+            sum = 2 * (a + b);
+
+        } else if (a != b) {
+            sum = a + b;
+        }
+        return sum;
+    }}


### PR DESCRIPTION
The sumDouble method adds two numbers a and b, but if the numbers are the same, it returns double their sum; otherwise, it just returns the regular sum.