### PR TITLE
TRA692: Not String – Add "not " Prefix Unless Already Present

### DIFF
--- a/plag_test_tool/from_Haitham/TRA692.java
+++ b/plag_test_tool/from_Haitham/TRA692.java
@@ -1,0 +1,8 @@
+public class TRA692{
+public static String notString(String str) {
+        if (str.equals("not " + str.substring(4))) {
+            return str;
+        }
+        return "not " + str;
+    }
+}


### PR DESCRIPTION
Implement a method notString(String str) that returns a new string where "not " is added to the front.
If the original string already starts with "not", return it unchanged.