### PR TITLE
TRA697: Or35 – Check if Number is Multiple of 3 or 5

### DIFF
--- a/plag_test_tool/from_Haitham/TRA697.java
+++ b/plag_test_tool/from_Haitham/TRA697.java
@@ -1,0 +1,8 @@
+public class TRA697{
+public static boolean or35(int n) {
+        if (n % 3 == 0 || n % 5 == 0) {
+            return true;
+        } else
+            return false;
+    }
+	}


### PR DESCRIPTION
Implement a method or35(int n) that returns true if the given non-negative number n is a multiple of 3 or 5.