### PR TITLE
TRA730: Front22 – Add First Two Chars to Front and Back of String

### DIFF
--- a/plag_test_tool/from_Haitham/TRA730.java
+++ b/plag_test_tool/from_Haitham/TRA730.java
@@ -1,0 +1,9 @@
+public class TRA730{
+public static String front22(String str) {
+        if (str.length() == 2) {
+            return str + str + str;
+        } else if (str.length() > 2) {
+            return str.substring(0, 2) + str + str.substring(0, 2);
+        } else return "less than valid length of string";
+    }
+	}


### PR DESCRIPTION
Implement a method front22(String str) that returns a new string with the first two characters added to both the front and back of the original string.
note:
If the string length is less than 2, use the whole string as the prefix and suffix.