### PR TITLE
TRA746: MixStart – Check if String Starts with Any Char Followed by "ix"

### DIFF
--- a/plag_test_tool/from_Haitham/TRA746.java
+++ b/plag_test_tool/from_Haitham/TRA746.java
@@ -1,0 +1,7 @@
+public class TRA746{
+public static boolean mixStart(String str) {
+        if (str.startsWith("ix", 1)) {
+            return true;
+        } else return false;
+    }
+	}


### PR DESCRIPTION
Implement a method mixStart(String str) that returns true if the string begins with any character followed by "ix", return false otherwise.