### PR TITLE
TRA814:Not String – Add "not " Prefix Unless Already Present

### DIFF
--- a/Not String.txt
+++ b/Not String.txt
@@ -1,0 +1,10 @@
+public class NotString {
+    public static String notString(String str) {
+        if (str.equals("not") || str.startsWith("not")) {
+            return str ;
+        }
+         else  {
+          return "not "+ str;
+        }
+    }
+}


### PR DESCRIPTION
Implement a method `notString(String str)` that returns a new string with `"not "` added to the front unless the original string already starts with `"not"`. If the string begins with `"not"`, return it unchanged. Use `.equals()` or `.startsWith()` for accurate string comparison. This task helps practice string manipulation and conditional logic. For example, `notString("candy")` returns `"not candy"`, `notString("x")` returns `"not x"`, and `notString("not bad")` returns `"not bad"`.
