### PR TITLE
TRA544: Not String - Add not  Prefix Unless Already Present

### DIFF
--- a/Shaima/NotString.txt
+++ b/Shaima/NotString.txt
@@ -1,0 +1,20 @@
+public class NotString {
+    public static String notString(String str) {
+
+        if (str.length() >=3 && str.substring(0,3).equals("not"))
+        {
+            return str;
+        }
+        else {
+            return "not " + str;
+
+        }
+    }
+
+    public static void main(String[] args) {
+        System.out.println(NotString.notString("candy"));
+        System.out.println(NotString.notString("x"));
+        System.out.println(NotString.notString("not bad"));
+    }
+
+}


### PR DESCRIPTION
The notString method adds "not " to the front of the string, unless it already starts with "not" — then it returns the string as it is.