### PR TITLE
solution of MakeOutWord task

### DIFF
--- a/From_Mulk/MakeOutWord.java
+++ b/From_Mulk/MakeOutWord.java
@@ -1,0 +1,5 @@
+public class MakeOutWord {
+    public String insertWordBetweenTags(String out, String word) {
+        return out.substring(0, 2) + word + out.substring(2);
+    }
+}


### PR DESCRIPTION
In the MakeOutWord class, I implemented a method called insertWordBetweenTags that takes two string parameters: out and word. This method inserts the word into the out string after its first two characters. It does this by extracting the first two characters of out using out.substring(0, 2), concatenating the word, and then appending the remainder of out starting from the third character with out.substring(2). The method returns the new string, effectively placing the word right after the first two characters of out. For example, if out is "<<>>" and word is "Yay", the result would be "<<Yay>>".