### PR TITLE
solution of DeFront task

### DIFF
--- a/From_Mulk/DeFront.java
+++ b/From_Mulk/DeFront.java
@@ -1,0 +1,20 @@
+public class DeFront {
+    public String cleanFirstTwoX(String str) {
+        if (str.isEmpty()) {
+            return "";
+
+        }
+        if (str.length() >= 2 && str.charAt(0) == 'x' && str.charAt(1) == 'x') {
+            return str.substring(2);
+        }
+
+        if (str.length() >= 1 && str.charAt(0) == 'x') {
+            return str.substring(1);
+        }
+        if (str.length() >= 1 && str.charAt(1) == 'x') {
+            return str.charAt(0) + str.substring(2);
+        }
+        return str;
+
+    }
+}


### PR DESCRIPTION
In this code, a method named cleanFirstTwoX is defined within the DeFront class to remove 'x' characters from the first two positions of a given string. It first checks if the string is empty and returns an empty string. Then, it checks if both the first and second characters are 'x' and removes them by returning the substring starting from index 2. If only the first character is 'x', it removes it; if only the second character is 'x', it removes just that character by keeping the first and appending the rest from the third character onward. If neither of the first two characters is 'x', it returns the original string.