### PR TITLE
solution of WithoutX task

### DIFF
--- a/From_Mulk/WithoutX.java
+++ b/From_Mulk/WithoutX.java
@@ -1,0 +1,24 @@
+public class WithoutX {
+    public String trimXEdges(String str) {
+        if (str.isEmpty()) {
+            return "";
+        }
+        if (str.length() == 1 && str.equals("x")) {
+            return "";
+        }
+        if (str.endsWith("x") && str.startsWith("x")) {
+            return str.substring(1, str.length() - 1);
+        }
+        if (str.startsWith("x")) {
+            return str.substring(1);
+        }
+        if (str.endsWith("x")) {
+            return str.substring(0, str.length() - 1);
+        }
+        if (!str.endsWith("x") && !str.startsWith("x")) {
+            return str;
+        } else {
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
In this code, the trimXEdges method inside the WithoutX class removes any 'x' characters that appear at the beginning and/or end of the input string str. It first checks if the string is empty or a single 'x', returning an empty string in both cases. If the string starts and ends with 'x', it removes both by returning the middle portion. If it starts with 'x', it removes the first character; if it ends with 'x', it removes the last character. If the string has no 'x' at either end, it returns the original string.


