### PR TITLE
solution of WithoutXTwo task

### DIFF
--- a/From_Mulk/WithoutXTwo.java
+++ b/From_Mulk/WithoutXTwo.java
@@ -1,0 +1,20 @@
+public class WithoutXTwo {
+    public String trimXFromStartTwo(String str) {
+        if (str.isEmpty()) {
+            return "";
+
+        }
+        if (str.length() >= 2 && str.charAt(0) == 'x' && str.charAt(1) == 'x') {
+            return str.substring(2);
+        }
+
+        if (str.length() >= 1 && str.charAt(0) == 'x') {
+            return str.substring(1);
+        }
+        if (str.length() >= 1 && str.charAt(1) == 'x') {
+            return str.charAt(0) + str.substring(2);
+        }
+        return str;
+
+    }
+}


### PR DESCRIPTION
In this code, the trimXFromStartTwo method in the WithoutXTwo class removes 'x' characters from the first two positions of the input string str. It first checks if the string is empty and returns an empty string. If both the first and second characters are 'x', it removes them by returning the substring starting from index 2. If only the first character is 'x', it removes it; if only the second character is 'x', it removes just that character by combining the first character with the substring starting from index 2. If neither of the first two characters is 'x', it returns the original string.


