### PR TITLE
TRA 2768:Logic-1 > withoutDoubles

### DIFF
--- a/from_hanin/DiceGame.java
+++ b/from_hanin/DiceGame.java
@@ -1,0 +1,13 @@
+public class DiceGame {
+    public int sumWithoutDoubles(int die1, int die2, boolean noDoubles) {
+        if (noDoubles && die1 == die2) {
+            if (die1 == 6) {
+                die1 = 1;
+            } else {
+                die1 = die1 + 1;
+            }
+        }
+        //Return the sum of two 6-sided dice rolls
+        return die1 + die2;
+    }
+}


### PR DESCRIPTION
The method `sumWithoutDoubles` calculates the sum of two dice rolls, `die1` and `die2`, with special handling when the `noDoubles` flag is `true`. If doubles are not allowed (`noDoubles` is `true`) and both dice show the same value, the method increments `die1` by 1 to avoid a double; if `die1` is already 6, it wraps around to 1. Finally, it returns the sum of the adjusted `die1` and `die2`. 
