### PR TITLE
Logic-1 > WithoutDoubles task

### DIFF
--- a/From_Mulk/WithoutDoubles.java
+++ b/From_Mulk/WithoutDoubles.java
@@ -1,0 +1,14 @@
+public class WithoutDoubles {
+    public int sumWithoutDoubles(int die1, int die2, boolean noDoubles) {
+        if (die1 == 6 && die2 == 6 && noDoubles) {
+            return die2 + 1;
+        }
+        if (die1 >= 1 && die1 <= 6 && die2 >= 1 && die2 <= 6 && noDoubles && die1 == die2) {
+            return die1 + die2 + 1;
+        }
+        if (die1 >= 1 && die1 <= 6 && die2 >= 1 && die2 <= 6 && noDoubles) {
+            return die1 + die2;
+        }
+        return die1 + die2;
+    }
+}


### PR DESCRIPTION
This method takes two dice rolls (die1 and die2) and a boolean noDoubles. Normally, it returns the sum of the dice. If noDoubles is true and the dice show the same number, it increases the second die by 1 to avoid doubles unless both dice show 6, then it just adds 1 to the second die’s value (which might go beyond 6). If noDoubles is false or the dice are different, it simply returns their sum.