### PR TITLE
#TRA-3477: Warmup-1 > NotString 

### DIFF
--- a/from_Muiayed/NotString.java
+++ b/from_Muiayed/NotString.java
@@ -1,0 +1,9 @@
+public class NotString {
+    public String notString(String str) {
+        if (str.length () >= 3 && str.substring(0, 3).equals("not")){
+            return str;
+        }
+        return "not " + str;
+    }
+
+}


### PR DESCRIPTION
The `NotString` class contains a method called `notString` that manipulates a given string based on whether it starts with the word `"not"`. If the input string already begins with `"not"` (checked using `str.substring(0, 3).equals("not")`), the method simply returns the original string unchanged. However, if it doesn't, the method prepends `"not "` to the beginning of the string and returns the modified result. This kind of logic is useful in scenarios where you want to ensure a specific prefix is present in a string, such as for tagging, formatting, or enforcing a naming convention. The method is concise, readable, and demonstrates basic string handling in Java.
