### PR TITLE
Task is done

### DIFF
--- a/from_Muiayed/WithoutX2.java
+++ b/from_Muiayed/WithoutX2.java
@@ -1,0 +1,23 @@
+public class WithoutX2 {
+
+        public static String withoutX2(String str) {
+            int len = str.length();
+            if (len == 0) return str;
+
+            StringBuilder sb = new StringBuilder();
+
+            if (len >= 1 && str.charAt(0) != 'x') sb.append(str.charAt(0));
+            if (len >= 2 && str.charAt(1) != 'x') sb.append(str.charAt(1));
+            if (len > 2) sb.append(str.substring(2));
+
+            return sb.toString();
+        }
+
+        public static void main(String[] args) {
+            System.out.println(withoutX2("xHi"));
+            System.out.println(withoutX2("Hxi"));
+            System.out.println(withoutX2("Hi"));
+            System.out.println(withoutX2("xx"));
+            System.out.println(withoutX2("ax"));  
+        }
+    }


### PR DESCRIPTION
The `WithoutX2` class in Java defines a method that removes any `'x'` characters found in the first two positions of a given string, while leaving the rest of the string untouched. This is accomplished by checking each of the first two characters individually and appending them to a `StringBuilder` only if they are not `'x'`. If the string is longer than two characters, the remaining portion from index 2 onward is appended regardless of its content. This approach ensures that only the initial `'x'` characters are filtered out, making it useful for cleaning up prefixes or formatting inputs. For example, `"xHi"` becomes `"Hi"`, `"Hxi"` becomes `"Hi"`, `"Hi"` remains `"Hi"`, `"xx"` becomes an empty string, and `"ax"` becomes `"a"`. The method showcases precise character-level control and conditional logic in string manipulation.
