### PR TITLE
#TRA-3686: Logic-1 > Old35 

### DIFF
--- a/from_Muiayed/Old35.java
+++ b/from_Muiayed/Old35.java
@@ -1,0 +1,14 @@
+public class Old35 {
+
+    public static boolean old35(int n) {
+        boolean div3 = n % 3 == 0;
+        boolean div5 = n % 5 == 0;
+        return (div3 || div5) && !(div3 && div5);
+    }
+
+    public static void main(String[] args) {
+        System.out.println(old35(3));  // true
+        System.out.println(old35(10)); // true
+        System.out.println(old35(15)); // false
+    }
+}


### PR DESCRIPTION
The `Old35` class in Java showcases a smart use of boolean logic to determine whether a number is divisible by either 3 or 5, but not both. The method `old35(int n)` first checks divisibility using the modulo operator and stores the results in two boolean variables: `div3` and `div5`. It then returns `true` only if one of these conditions is true exclusively, using the expression `(div3 || div5) && !(div3 && div5)`. This ensures that numbers like 3 and 10 return `true`, while 15—divisible by both—returns `false`. This kind of logic is particularly useful in scenarios where overlapping conditions must be filtered out, such as eligibility rules, game mechanics, or custom business logic. The structure is clean, readable, and demonstrates how combining simple checks can lead to precise control over program behavior.
