### PR TITLE
#TRA-3699: Logic-1 > WithoutDoubles 

### DIFF
--- a/from_Muiayed/WithoutDoubles.java
+++ b/from_Muiayed/WithoutDoubles.java
@@ -1,0 +1,15 @@
+public class WithoutDoubles {
+
+    public static int withoutDoubles(int die1, int die2, boolean noDoubles) {
+        if (noDoubles && die1 == die2) {
+            die1 = (die1 == 6) ? 1 : die1 + 1;
+        }
+        return die1 + die2;
+    }
+
+    public static void main(String[] args) {
+        System.out.println(withoutDoubles(2, 3, true));  // 5
+        System.out.println(withoutDoubles(3, 3, true));  // 7
+        System.out.println(withoutDoubles(3, 3, false)); // 6
+    }
+}


### PR DESCRIPTION
The `WithoutDoubles` class in Java defines a method that calculates the sum of two dice rolls, with an optional rule to avoid doubles. The method `withoutDoubles(int die1, int die2, boolean noDoubles)` checks if the `noDoubles` flag is set to `true` and both dice show the same value. If so, it adjusts `die1` by incrementing it—unless it's already 6, in which case it wraps around to 1, simulating a standard die roll. This ensures that the result avoids a double while staying within valid die values. The method then returns the sum of the two dice. In the `main` method, the first example returns 5 because the dice are different; the second returns 7 because the double 3 is adjusted to 4; and the third returns 6 because doubles are allowed. This class cleverly handles dice logic with a twist, making it useful for games that require variation in outcomes.
