### PR TITLE
#TRA-3704: Logic-1 > ShareDigit 

### DIFF
--- a/from_Muiayed/ShareDigit.java
+++ b/from_Muiayed/ShareDigit.java
@@ -1,0 +1,17 @@
+public class ShareDigit {
+
+    public static boolean shareDigit(int a, int b) {
+        int a1 = a / 10;
+        int a2 = a % 10;
+        int b1 = b / 10;
+        int b2 = b % 10;
+
+        return a1 == b1 || a1 == b2 || a2 == b1 || a2 == b2;
+    }
+
+    public static void main(String[] args) {
+        System.out.println(shareDigit(12, 23)); // true
+        System.out.println(shareDigit(12, 43)); // false
+        System.out.println(shareDigit(12, 44)); // false
+    }
+}


### PR DESCRIPTION
The `ShareDigit` class in Java defines a method that checks whether two two-digit numbers share at least one digit. The method `shareDigit(int a, int b)` extracts the tens and units digits of both numbers using division and modulo operations. Specifically, `a1` and `a2` represent the tens and units digits of `a`, while `b1` and `b2` represent those of `b`. The method then compares all combinations of these digits and returns `true` if any match is found. In the `main` method, the first example `shareDigit(12, 23)` returns `true` because both numbers share the digit 2; the second and third examples return `false` since there are no shared digits. This class provides a simple and efficient way to detect digit overlap between two numbers.
