### PR TITLE
#TRA4197: String-3 > notReplace

### DIFF
--- a/from_Muiayed/notReplace.java
+++ b/from_Muiayed/notReplace.java
@@ -1,0 +1,34 @@
+public class notReplace {
+
+    public static void main(String[] args) {
+        // Test cases
+        System.out.println(notReplace("is test"));
+        System.out.println(notReplace("is-is"));
+        System.out.println(notReplace("This is right"));
+        System.out.println(notReplace("isthis"));
+        System.out.println(notReplace("is 123 is"));
+    }
+
+    public static String notReplace(String str) {
+        StringBuilder result = new StringBuilder();
+        int i = 0;
+
+        while (i < str.length()) {
+            // Check if "is" starts at position i
+            if (i + 1 < str.length() &&
+                    str.charAt(i) == 'i' &&
+                    str.charAt(i + 1) == 's' &&
+                    (i == 0 || !Character.isLetter(str.charAt(i - 1))) &&
+                    (i + 2 == str.length() || !Character.isLetter(str.charAt(i + 2)))) {
+
+                result.append("is not");
+                i += 2; // Skip past "is"
+            } else {
+                result.append(str.charAt(i));
+                i++;
+            }
+        }
+
+        return result.toString();
+    }
+}


### PR DESCRIPTION
The notReplace class modifies a given string by replacing standalone occurrences of the word "is" with "is not", while preserving embedded instances like "isthis" or "this". The notReplace method uses a StringBuilder to construct the result and iterates through the string character by character. It checks whether "is" appears at the current position and ensures it's not part of a larger word by verifying that the characters before and after are not letters. If the condition is met, it appends "is not" and skips ahead; otherwise, it appends the current character. This logic ensures accurate word-boundary detection and avoids false replacements. The main method showcases various test cases, demonstrating the method’s precision in handling different contexts
