### PR TITLE
TRA-3316: PrefixAgain task is done

### DIFF
--- a/from_Haitham/PrefixAgain.java
+++ b/from_Haitham/PrefixAgain.java
@@ -1,0 +1,10 @@
+public class PrefixAgain {
+ public boolean prefixAgainChecker(String str, int n) {
+        String prefix = str.substring(0, n);
+        int count = 0;
+        for (int i = 0; i <= str.length() - n; i++) {
+            if (str.substring(i, n + i).equals(prefix)) count++;
+        }
+        return count > 1;
+    }
+	}


### PR DESCRIPTION
The `PrefixAgain` class contains a method called `prefixAgainChecker` that checks whether the prefix of length `n` in a given string `str` appears **again somewhere else** in the string. It first extracts the prefix substring of length `n`, then iterates through the string to count how many times this prefix occurs. If the prefix appears more than once (meaning it occurs at least once beyond the start), the method returns `true`; otherwise, it returns `false`. For example, with input `"abXYabc"` and `n = 2`, the prefix `"ab"` appears twice, so the method would return `true`.
