### PR TITLE
TRA-3322: StarOut task is done

### DIFF
--- a/from_Haitham/StarOut.java
+++ b/from_Haitham/StarOut.java
@@ -1,0 +1,13 @@
+public class StarOut {
+public String starBehindRemover(String str) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < str.length(); i++) {
+            if (str.charAt(i) == '*') continue;
+            if (i > 0 && str.charAt(i - 1) == '*') continue;
+            if (i < str.length() - 1 && str.charAt(i + 1) == '*') continue;
+            result.append(str.charAt(i));
+        }
+        return result.toString();
+
+    }
+	}


### PR DESCRIPTION
The `StarOut` class contains a method named `starBehindRemover` that removes all `'*'` characters from the input string **along with the characters immediately next to them** (both before and after). It loops through each character in the string and uses conditions to skip characters that are either a `'*'` or are adjacent to a `'*'`. Only characters that are not `'*'` and not directly next to a `'*'` are added to the result. For example, given `"ab*cd"`, the method would return `"ad"` (removing `'*'` and the characters `'b'` and `'c'`). The method uses a `StringBuilder` for efficient string construction.
