### PR TITLE
#TRA-4333: Array-2 > zeroFront

### DIFF
--- a/from_Muiayed/ZeroFront.java
+++ b/from_Muiayed/ZeroFront.java
@@ -1,0 +1,17 @@
+import java.util.Arrays;
+
+public class ZeroFront {
+    public static int[] zeroFront(int[] nums) {
+        int[] res = new int[nums.length];
+        int z = 0;
+        for (int n : nums) if (n == 0) res[z++] = 0;
+        for (int n : nums) if (n != 0) res[z++] = n;
+        return res;
+    }
+
+    public static void main(String[] args) {
+        System.out.println(Arrays.toString(zeroFront(new int[]{1, 0, 0, 1})));
+        System.out.println(Arrays.toString(zeroFront(new int[]{0, 1, 1, 0, 1})));
+        System.out.println(Arrays.toString(zeroFront(new int[]{1, 0})));
+    }
+}


### PR DESCRIPTION
The ZeroFront class defines a method that rearranges an integer array so that all zeroes are moved to the front, while preserving the order of non-zero elements. The zeroFront method creates a new array of the same length and uses a two-pass approach: the first loop inserts all zeroes at the beginning, and the second loop appends the non-zero values after them. This ensures a clean separation between zero and non-zero elements without sorting or modifying the original order. The main method demonstrates this with examples like [0, 0, 1, 1], [0, 0, 1, 1, 1], and [0, 1].
