### PR TITLE
#TRA-4339: Array-3 > fix34

### DIFF
--- a/from_Muiayed/Fix34.java
+++ b/from_Muiayed/Fix34.java
@@ -1,0 +1,30 @@
+public class Fix34 {
+    public static int[] fix34(int[] nums) {
+        int[] arr = nums.clone();
+        int j = 0;
+
+        for (int i = 0; i < arr.length - 1; i++) {
+            if (arr[i] == 3 && arr[i + 1] != 4) {
+                // find the next 4 that is not directly after a 3
+                while (j < arr.length && (arr[j] != 4 || (j > 0 && arr[j - 1] == 3))) {
+                    j++;
+                }
+                // swap the 4 into position i+1
+                int temp = arr[i + 1];
+                arr[i + 1] = arr[j];
+                arr[j] = temp;
+            }
+        }
+        return arr;
+    }
+
+    // quick sanity check
+    public static void main(String[] args) {
+        java.util.function.Consumer<int[]> print =
+                a -> System.out.println(java.util.Arrays.toString(a));
+
+        print.accept(fix34(new int[]{1, 3, 1, 4}));          // [1, 3, 4, 1]
+        print.accept(fix34(new int[]{1, 3, 1, 4, 4, 3, 1})); // [1, 3, 4, 1, 1, 3, 4]
+        print.accept(fix34(new int[]{3, 2, 2, 4}));          // [3, 4, 2, 2]
+    }
+}


### PR DESCRIPTION
The `fix34` problem focuses on rearranging elements in an integer array so that every `3` is immediately followed by a `4`. The assumption is that the array contains the same number of `3`s and `4`s, and no `3` is followed by another `3`. The goal is to preserve the relative order of other elements while ensuring that each `3` is paired with a `4` directly after it. The method works by scanning the array for any `3` not followed by a `4`, then searching for a standalone `4` (one not already placed after a `3`) and swapping it into the correct position. This approach uses a clone of the original array to avoid modifying it directly and ensures that each `3` gets its own `4` without disrupting the rest of the array. It's a great exercise in array manipulation, nested loops, and conditional logic.
