### PR TITLE
#TRA-4340: Array-3 > fix45

### DIFF
--- a/from_Muiayed/Fix45.java
+++ b/from_Muiayed/Fix45.java
@@ -1,0 +1,27 @@
+import java.util.Arrays;
+
+public class Fix45 {
+    public static int[] fix45(int[] nums) {
+        int[] arr = nums.clone();
+        int j = 0;
+        for (int i = 0; i < arr.length - 1; i++) {
+            if (arr[i] == 4 && arr[i + 1] != 5) {
+                // locate the next 5 that is NOT directly after a 4
+                while (j < arr.length && (arr[j] != 5 || (j > 0 && arr[j - 1] == 4))) {
+                    j++;
+                }
+                // swap that 5 into position i+1
+                int temp = arr[i + 1];
+                arr[i + 1] = arr[j];
+                arr[j] = temp;
+            }
+        }
+        return arr;
+    }
+
+    public static void main(String[] args) {
+        System.out.println(Arrays.toString(fix45(new int[]{5, 4, 9, 4, 9, 5})));
+        System.out.println(Arrays.toString(fix45(new int[]{1, 4, 1, 5})));
+        System.out.println(Arrays.toString(fix45(new int[]{1, 4, 1, 5, 5, 4, 1})));
+    }
+}


### PR DESCRIPTION
The fix45 problem is a classic array manipulation challenge where the goal is to rearrange elements so that every 4 is immediately followed by a 5. The assumption is that the array contains equal numbers of 4s and 5s, and no 4 is followed by another 4. The method works by scanning the array for any 4 not followed by a 5, then searching for a standalone 5—one that isn’t already placed directly after a 4. Once found, it swaps that 5 into the correct position after the 4. This ensures that each 4 is paired with a 5 without disrupting the rest of the array’s structure. The use of a cloned array preserves the original input, and the nested loop logic ensures that each 5` is used only once. It’s a great exercise in control flow, array traversal, and understanding how to maintain constraints while modifying data in-place.
