### PR TITLE
#TRA-4482: Functional-2 > noLong

### DIFF
--- a/from_Muiayed/noLong.java
+++ b/from_Muiayed/noLong.java
@@ -1,0 +1,16 @@
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class noLong {
+    public static List<String> noLong(List<String> strings) {
+        strings.removeIf(s -> s.length() >= 4);
+        return strings;
+    }
+
+    public static void main(String[] args) {
+        System.out.println(noLong(new ArrayList<>(Arrays.asList("this", "not", "too", "long"))));
+        System.out.println(noLong(new ArrayList<>(Arrays.asList("a", "bbb", "cccc"))));
+        System.out.println(noLong(new ArrayList<>(Arrays.asList("cccc", "cccc", "cccc"))));
+    }
+}


### PR DESCRIPTION
This Java program defines a class called `noLong` that filters out strings with a length of four or more characters from a list. The method `noLong` takes a list of strings and uses the `removeIf` method with a lambda expression to eliminate any string whose length is greater than or equal to four. In the `main` method, the program demonstrates this functionality with three sample lists. For instance, the input `["this", "not", "too", "long"]` results in `["not", "too"]`, since "this" and "long" are four characters long and get removed. Similarly, `["a", "bbb", "cccc"]` becomes `["a", "bbb"]`, and `["cccc", "cccc", "cccc"]` is reduced to an empty list because all elements meet the removal condition. This approach showcases a concise and effective use of Java’s functional programming features for string filtering.
