### PR TITLE
Tra 4362: Recursion-2 > groupNoAdj

### DIFF
--- a/from_hanin/SkipAdjacentPicker.java
+++ b/from_hanin/SkipAdjacentPicker.java
@@ -1,0 +1,12 @@
+public class SkipAdjacentPicker {
+    public boolean isSumPossible(int start, int[] nums, int target) {
+        if (target == 0) {
+            return true;
+        } else if (start >= nums.length) {
+            return false;
+        } else {
+            return isSumPossible(start + 1, nums, target) || isSumPossible(start + 2, nums, target - nums[start]);
+        }
+    }
+
+}


### PR DESCRIPTION
The `groupNoAdj` method checks if it's possible to pick a group of non-adjacent numbers from the array `nums`, starting at index `start`, that adds up to the given `target`. It works recursively: first, if the `target` is 0, it returns `true` (a valid subset is found). If the index goes beyond the array length, it returns `false` (no valid subset). Otherwise, it tries two choices — skip the current number and move to the next index (`start + 1`), or include the current number (subtract it from the target) and skip the next index (`start + 2`) to avoid picking adjacent numbers. If either choice leads to the target, it returns `true`.
