### PR TITLE
Tra 4363: Recursion-2 > groupSum5

### DIFF
--- a/from_hanin/MultiplesOfFiveSubset.java
+++ b/from_hanin/MultiplesOfFiveSubset.java
@@ -1,0 +1,21 @@
+public class MultiplesOfFiveSubset {
+    public boolean canSumWithRules(int start, int[] nums, int target) {
+        if (start == nums.length) {
+            return target == 0;
+        }
+        if (nums[start] % 5 == 0) {
+            // Must include multiples of 5
+            if (start + 1 < nums.length && nums[start + 1] == 1) {
+                // Skip the 1 after a multiple of 5
+                return canSumWithRules(start + 2, nums, target - nums[start]);
+            } else {
+                return canSumWithRules(start + 1, nums, target - nums[start]);
+            }
+        } else {
+
+            return canSumWithRules(start + 1, nums, target) || canSumWithRules(start + 1, nums, target - nums[start]);
+        }
+    }
+
+}
+


### PR DESCRIPTION
The `groupSum5` method checks if a subset of numbers can sum to a target, with special rules: all multiples of 5 must be included, and if a 1 follows a multiple of 5, it must be skipped. For other numbers, it tries both including and excluding them. It returns true if any valid combination adds up to the target.
