### PR TITLE
Tra 4364: Recursion-2 > groupSumClump

### DIFF
--- a/from_hanin/ClumpedGroupSum.java
+++ b/from_hanin/ClumpedGroupSum.java
@@ -1,0 +1,16 @@
+public class ClumpedGroupSum {
+    public boolean canSumWithClumps(int start, int[] nums, int target) {
+        if (target == 0) {
+            return true;
+        } else if (start >= nums.length) {
+            return false;
+        } else {
+            int end = start;
+            while (end < nums.length && nums[end] == nums[start]) end++;
+            int length = end - start;
+            return canSumWithClumps(end, nums, target) || canSumWithClumps(end, nums, target - nums[start] * length);
+        }
+    }
+
+}
+


### PR DESCRIPTION
The `groupSumClump` method checks if a subset of numbers can sum to a target, treating adjacent identical numbers as a single "clump" that must be either all included or all excluded. It finds the size of each clump starting at index `start`, then recursively tries both options: skipping the clump or including the entire clump (value × count). It returns true if any valid combination of clumps adds up to the target.
