### PR TITLE
TRA-4436: Recursion-1 >=The solution for Recursion-1 > countHi2 Task

### DIFF
--- a/from_Kaltham/HiStringCounter.java
+++ b/from_Kaltham/HiStringCounter.java
@@ -1,0 +1,19 @@
+//Recursion-1 > countHi2
+
+public class HiStringCounter {
+    public int countHiExcludingX(String str) {
+        if (str.length() <= 1) {
+            return 0;
+        }
+
+        if (str.length() > 2 && str.substring(0, 3).equals("xhi")) {
+            return countHiExcludingX(str.substring(3));
+        }
+        if (str.length() > 1 && str.substring(0, 2).equals("hi")) {
+            return 1 + countHiExcludingX(str.substring(2));
+        }
+
+        return countHiExcludingX(str.substring(1));
+
+    }
+}


### PR DESCRIPTION
I created a class called HiStringCounter with a method named countHiExcludingX that counts the occurrences of "hi" in a string, but ignores any "hi" that is immediately preceded by 'x', using recursion.

How it works:

Base case:

If the string length is 1 or less, return 0 because "hi" can’t exist.

Check for "xhi":

If the first three characters are "xhi", skip them and recursively process the rest of the string (str.substring(3)) because this "hi" should not be counted.

Check for "hi":

If the first two characters are "hi", add 1 and recursively process the rest of the string starting after the "hi" (str.substring(2)).

Otherwise:

Recursively process the string starting from the next character (str.substring(1)).

The recursion continues until the string is fully processed, giving the total count of "hi" that are not preceded by 'x'.