### PR TITLE
TRA-4382-Recursion-2: groupSumClump

### DIFF
--- a/From_Manal/GroupSumClumpSolver.java
+++ b/From_Manal/GroupSumClumpSolver.java
@@ -1,0 +1,27 @@
+public class ClumpSumSolver {
+
+    public static boolean canReachTargetWithClumps(int startIndex, int[] numbers, int target) {
+        //  if we reached the end of the array
+        if (startIndex >= numbers.length) {
+            return target == 0;
+        }
+
+        int clumpSum = 0;
+        int nextIndex;
+        for (nextIndex = startIndex; nextIndex < numbers.length; nextIndex++) {
+            if (numbers[nextIndex] == numbers[startIndex]) {
+                clumpSum += numbers[nextIndex];
+            } else {
+                break;
+            }
+        }
+
+        return canReachTargetWithClumps(nextIndex, numbers, target - clumpSum) || canReachTargetWithClumps(nextIndex, numbers, target);
+    }
+
+    public static void main(String[] args) {
+        System.out.println(canReachTargetWithClumps(0, new int[]{2, 4, 8}, 10));
+        System.out.println(canReachTargetWithClumps(0, new int[]{1, 2, 4, 8, 1}, 14));
+        System.out.println(canReachTargetWithClumps(0, new int[]{2, 4, 4, 8}, 14));
+    }
+}


### PR DESCRIPTION
Implemented groupSumClump(start, nums, target) to determine if a subset of integers can sum to a target value, with the constraint that adjacent identical values (clumps) must be treated as a single decision unit—either all included or all excluded.
Used one loop to detect clump boundaries, then applied recursive backtracking to explore valid groupings. No loops used beyond clump detection.