### PR TITLE
Map-2 > FirstSwap task

### DIFF
--- a/From_Mulk/LimitedCharSwap.java
+++ b/From_Mulk/LimitedCharSwap.java
@@ -1,0 +1,26 @@
+//Map-2 > firstSwap
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LimitedCharSwap {
+    public String[] singleSwapPerStartingChar(String[] strings) {
+        Map<String, Integer> map = new HashMap<>();
+
+        for (int i = 0; i < strings.length; i++) {
+            String firstChar = strings[i].substring(0, 1);
+
+            if (!map.containsKey(firstChar)) {
+                map.put(firstChar, i);
+            } else if (map.get(firstChar) != -1) {
+                int j = map.get(firstChar);
+                String temp = strings[j];
+                strings[j] = strings[i];
+                strings[i] = temp;
+                map.put(firstChar, -1);
+            }
+        }
+
+        return strings;
+    }
+}


### PR DESCRIPTION
This method swaps the first two words that share the same starting letter and ensures each starting letter only causes one swap by marking it as used after the first swap.