### PR TITLE
#TRA4975: Recursion -1 > countHi2

### DIFF
--- a/from_Muiayed/CountHi2.java
+++ b/from_Muiayed/CountHi2.java
@@ -1,0 +1,14 @@
+public class CountHi2 {
+  public static void main(String[] args) {
+    System.out.println(countHi2("ahixhi"));
+    System.out.println(countHi2("ahibhi"));
+    System.out.println(countHi2("xhixhi"));
+  }
+
+  public static int countHi2(String str) {
+    if (str.length() < 2) return 0;
+    if (str.substring(0, 2).equals("hi")) return 1 + countHi2(str.substring(2));
+    if (str.length() >= 3 && str.charAt(0) == 'x' && str.substring(1, 3).equals("hi")) return countHi2(str.substring(3));
+    return countHi2(str.substring(1));
+  }
+}


### PR DESCRIPTION
The `CountHi2` class in Java defines a recursive method that counts the number of `"hi"` substrings in a given string, with one important exception: it skips any `"hi"` that is immediately preceded by an `'x'`. The method `countHi2` begins by checking if the string is too short to contain `"hi"`—if so, it returns 0. Then, it checks if the first two characters are `"hi"` and not preceded by `'x'`; if they are, it counts one occurrence and skips ahead by two characters to avoid overlapping. If the substring `"hi"` is preceded by `'x'`, the method skips all three characters (`'xhi'`) and continues the recursion. Otherwise, it moves forward one character and continues checking. This logic ensures accurate counting of `"hi"` while excluding cases like `"xhi"`. For example, `"ahixhi"` returns 1, `"ahibhi"` returns 2, and `"xhixhi"` returns 0. The method is a great example of conditional recursion and pattern filtering in string analysis.
