### PR TITLE
TRA-5103: Recursion-2 >=The solution for groupSumClump Task

### DIFF
--- a/from_Kaltham/ClumpedSubsetSumChecker.java
+++ b/from_Kaltham/ClumpedSubsetSumChecker.java
@@ -1,0 +1,36 @@
+//Recursion-2 > groupSumClump
+
+
+public class ClumpedSubsetSumChecker {
+    public boolean canAchieveTargetWithClumps(int start, int[]nums, int target) {
+        int sumClump = 0;
+        int nextIndex = 0;
+        if (start >= nums.length) {
+            return target == 0;
+        }
+
+        for (int i = start; i < nums.length; i++) {
+            if (nums[i] == nums[start]) {
+                sumClump += nums[i];
+            } else {
+                nextIndex = i;
+                break;
+            }
+        }
+
+        if (nextIndex == 0) {
+            nextIndex = nums.length;
+        }
+
+        if (canAchieveTargetWithClumps(nextIndex, nums, target - sumClump)) {
+            return true;
+        }
+
+        if (canAchieveTargetWithClumps(nextIndex, nums, target)) {
+            return true;
+        }
+
+        return false;
+    }
+
+}


### PR DESCRIPTION
The class ClumpedSubsetSumChecker has a method canAchieveTargetWithClumps that checks if a subset of numbers can sum to a given target, treating consecutive identical numbers as a single “clump.”

How it works:

It finds the sum of consecutive identical numbers starting at start.

Recursively, it either includes the clump in the sum or skips it.

Returns true if any combination reaches the target, false otherwise.